### PR TITLE
Add supported CPU architectures section to README and the Book

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,39 @@ in data centers, autonomous vehicles, and embodied AI.
 
 ## Getting Started
 
+### Supported CPU Architectures
+
+Asterinas targets modern, 64-bit platforms only.
+
+A **development platform** is where you build and test Asterinas
+(i.e., the host machine running the Docker-based development environment).
+
+| Development Platform |
+| -------------------- |
+| x86-64               |
+
+A **deployment platform** is a CPU architecture
+that Asterinas can run on as an OS kernel.
+
+| Deployment Platform | Tier   |
+| ------------------- | ------ |
+| x86-64              | Tier 1 |
+| x86-64 (Intel TDX)  | Tier 2 |
+| RISC-V 64           | Tier 2 |
+| LoongArch 64        | Tier 3 |
+
+Tier definitions:
+- **Tier 1:** Fully supported and tested.
+  CI runs the full test suite on every PR.
+- **Tier 2:** Actively developed with basic functionality working.
+  CI runs build checks and basic tests on a regular basis
+  (per PR for RISC-V and nightly for Intel TDX),
+  but the full test suite is not yet covered.
+- **Tier 3:** Early-stage or experimental.
+  The kernel can boot and perform basic operations,
+  but CI coverage is limited and
+  may not include automated runtime tests for every pull request.
+
 ### For End Users
 
 We provide [Asterinas NixOS ISO Installer](https://github.com/asterinas/asterinas/releases)

--- a/book/src/kernel/README.md
+++ b/book/src/kernel/README.md
@@ -25,10 +25,38 @@ thanks to the flexibility offered by [MPL](../).
 
 While the journey towards a production-grade OS kernel can be challenging,
 we are steadfastly progressing towards our goal.
-Currently, Asterinas only supports x86-64 VMs.
-However, [our aim for 2024](roadmap.md) is
-to make Asterinas production-ready on x86-64
-for both bare-metal and VM environments.
+
+## Supported CPU Architectures
+
+Asterinas targets modern, 64-bit platforms only.
+
+A **development platform** is where you build and test Asterinas
+(i.e., the host machine running the Docker-based development environment).
+
+| Development Platform |
+| -------------------- |
+| x86-64               |
+
+A **deployment platform** is a CPU architecture
+that Asterinas can run on as an OS kernel.
+
+| Deployment Platform | Tier   |
+| ------------------- | ------ |
+| x86-64              | Tier 1 |
+| x86-64 (Intel TDX)  | Tier 2 |
+| RISC-V 64           | Tier 2 |
+| LoongArch 64        | Tier 3 |
+
+- **Tier 1:** Fully supported and tested.
+  CI runs the full test suite on every PR.
+- **Tier 2:** Actively developed with basic functionality working.
+  CI runs build checks and basic tests on a regular basis
+  (per PR for RISC-V and nightly for Intel TDX),
+  but the full test suite is not yet covered.
+- **Tier 3:** Early-stage or experimental.
+  The kernel can boot and perform basic operations,
+  but CI coverage is limited and
+  may not include automated runtime tests for every pull request.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Add a "Supported CPU Architectures" section to the root `README.md`, documenting development and deployment platform tiers.
- Add the same section to the Book's kernel getting-started page (`book/src/kernel/README.md`), replacing stale text with the up-to-date tier table.

## Details

The new section covers:
- **Development platform:** x86-64 only.
- **Deployment platforms** with a three-tier classification:
  - **Tier 1:** x86-64 — full CI test suite on every PR.
  - **Tier 2:** x86-64 (Intel TDX) and RISC-V 64 — build checks and basic tests on a regular basis (per PR for RISC-V, nightly for Intel TDX).
  - **Tier 3:** LoongArch 64 — early-stage, limited CI coverage.

## Test plan
- [ ] Verify the tier table is accurate and consistent across `README.md` and `book/src/kernel/README.md`
- [ ] Build the mdBook (`make book`) and confirm the new section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)